### PR TITLE
Fix directory creation issues in extract.py

### DIFF
--- a/extract.py
+++ b/extract.py
@@ -500,6 +500,8 @@ def parse_params():
         print(cv2.getBuildInformation())
         return
 
+    os.makedirs(args.output_folder, mode=0o775, exist_ok=True)
+
     # setup extractor
     extractor = CPTVTrackExtractor(args.output_folder)
 

--- a/extract.py
+++ b/extract.py
@@ -245,12 +245,7 @@ class CPTVTrackExtractor(CPTVFileProcessor):
         else:
             max_tracks = 10
 
-        # make destination folder if required
-        try:
-            os.stat(destination_folder)
-        except:
-            self.log_message(" Making path " + destination_folder)
-            os.mkdir(destination_folder)
+        os.makedirs(destination_folder, mode=0o775, exist_ok=True)
 
         # check if we have already processed this file
         if self.needs_processing(stats_path_and_filename):


### PR DESCRIPTION
* Avoid race when creating output directories (fixes #8)
* Create output directory if it doesn't exist  (fixes #9)