### PR TITLE
Fix insecure deserialisation

### DIFF
--- a/ml_tools/config.py
+++ b/ml_tools/config.py
@@ -32,7 +32,7 @@ class Config(ConfigBaseTuple):
     def load(cls):
         filename = find_config()
         with open(filename) as stream:
-            yaml_map = yaml.load(stream)
+            yaml_map = yaml.safe_load(stream)
             cls.load_from_map(yaml_map)
 
     @classmethod
@@ -68,8 +68,7 @@ class Config(ConfigBaseTuple):
 
 def load_to_yaml(filename):
     with open(filename) as stream:
-        yaml_map = yaml.load(stream)
-    return yaml_map
+        return yaml.safe_load(stream)
 
 
 def find_config():


### PR DESCRIPTION
The config file parsing was vulnerable to yaml object injection due
to not using safe_load; as no object processing is required, this is
a trivial fix.