### PR TITLE
Fix multiprocess file extraction

### DIFF
--- a/ml_tools/cptvfileprocessor.py
+++ b/ml_tools/cptvfileprocessor.py
@@ -43,9 +43,6 @@ class CPTVFileProcessor:
         # number of threads to use when processing jobs.
         self.workers_threads = config.worker_threads
 
-        # default grayscale colormap
-        self.colormap = lambda x : (x*255,x*255,x*255)
-
         # optional initializer for worker threads
         self.worker_pool_init = None
 
@@ -97,7 +94,7 @@ class CPTVFileProcessor:
                 print("KeyboardInterrupt, terminating.")
                 pool.terminate()
                 exit()
-            except Exception as e:
+            except Exception:
                 logging.exception("Error processing files")
             else:
                 pool.close()


### PR DESCRIPTION

Lambda's cannot be pickled, and multiprocessing uses pickle as it's
data exchange protocol to worker processes.

An alternative fix would be to use worker threads, but I haven't
profiled this workload yet to see whether the GIL would be a limiting
factor or not.

self.colormap appears entirely unused.