### PR TITLE
build and train should use config files

### DIFF
--- a/build.py
+++ b/build.py
@@ -19,6 +19,7 @@ import datetime
 import numpy as np
 
 from ml_tools.trackdatabase import TrackDatabase
+import ml_tools.config
 from ml_tools.dataset import Dataset
 
 DATASET_FOLDER = 'c:/cac/datasets/fantail/'
@@ -64,7 +65,7 @@ LABEL_WEIGHTS = {
 
 # clips after this date will be ignored.
 # note: this is based on the UTC date.
-END_DATE = datetime(2018, 1, 31)
+END_DATE = datetime.datetime(2018, 1, 31)
 
 # minimum average mass for test segment
 TEST_MIN_MASS = 30
@@ -356,6 +357,10 @@ def get_bin_split(filename):
     return test_bins
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--config-file', help="Path to config file to use")
+    args = parser.parse_args()
+    config = ml_tools.config.load_from_map(conf)
 
     global dataset
     global db

--- a/ml_tools/config.py
+++ b/ml_tools/config.py
@@ -84,3 +84,12 @@ def deep_copy_map_if_key_not_exist(from_map, to_map):
             deep_copy_map_if_key_not_exist(from_map[key], to_map[key])
         elif key not in to_map:
             to_map[key] = from_map[key]
+
+
+def args_to_config(args):
+    """Convert an argparse args dict to a usable Config object."""
+    if args.config_file:
+        conf = Config.read_config_file(args.config_file)
+    else:
+        conf = Config.read_default_config_file()
+    return Config.load_from_map(conf)

--- a/train.py
+++ b/train.py
@@ -42,6 +42,8 @@ import tensorflow as tf
 
 from model_crnn import ModelCRNN_HQ, ModelCRNN_LQ
 
+import ml_tools.config
+
 # folder to put tensor board logs into
 LOG_FOLDER = "c:/cac/logs/"
 
@@ -208,8 +210,9 @@ def main():
     parser.add_argument('-d', '--dataset', default="datasets", help='Enables preview MPEG files (can be slow)')
     parser.add_argument('-e', '--epochs', default="30", help='Number of epochs to train for')
     parser.add_argument('-p', '--params', default="{}", help='model parameters')
-
+    parser.add_argument('-c', '--config-file', help="Path to config file to use")
     args = parser.parse_args()
+    config = ml_tools.config.load_from_map(conf)
 
     if args.name == "search":
         print("Performing hyper parameter search.")


### PR DESCRIPTION
I'm not sure enough of the semantics yet - should there be a dataset
hdf5 file per class? - but it seems clear that we'll want configuration
for the ML stages as well, so this patch makes that config accessible
to that code, to allow future changes to leverage it.

I suspect that a map of classes and parameters are needed in the config
but that should flow naturally enough once this is usable.