### PR TITLE
Prevent stray output to stdout - log to stderr

### DIFF
--- a/build.py
+++ b/build.py
@@ -18,6 +18,7 @@ import datetime
 
 import numpy as np
 
+from ml_tools.logs import init_logging
 from ml_tools.trackdatabase import TrackDatabase
 from ml_tools.dataset import Dataset
 
@@ -356,6 +357,7 @@ def get_bin_split(filename):
     return test_bins
 
 def main():
+    init_logging()
 
     global dataset
     global db

--- a/classify/clipclassifier.py
+++ b/classify/clipclassifier.py
@@ -39,9 +39,6 @@ class ClipClassifier(CPTVFileProcessor):
         # enables exports detailed information for each track.  If preview mode is enabled also enables track previews.
         self.enable_per_track_information = False
 
-        # writes metadata to standard out instead of a file.
-        self.write_meta_to_stdout = False
-
     def preprocess(self, frame, thermal_reference):
         """
         Applies preprocessing to frame required by the model.

--- a/classify/clipclassifier.py
+++ b/classify/clipclassifier.py
@@ -220,7 +220,6 @@ class ClipClassifier(CPTVFileProcessor):
             elif len(tags) == 1:
                 tag = tags[0] if tags[0] else "none"
             else:
-                print(tags)
                 tag = 'multi'
             meta_data["primary_tag"] = tag
             return meta_data
@@ -344,8 +343,7 @@ class ClipClassifier(CPTVFileProcessor):
             track_info['positions'] = positions
 
         if self.config.classify.meta_to_stdout:
-            output = json.dumps(save_file, indent=4, cls=tools.CustomJSONEncoder)
-            print(output)
+            print(json.dumps(save_file, cls=tools.CustomJSONEncoder))
         else:
-            f = open(meta_filename, 'w')
-            json.dump(save_file, f, indent=4, cls=tools.CustomJSONEncoder)
+            with open(meta_filename, 'w') as f:
+                json.dump(save_file, f, indent=4, cls=tools.CustomJSONEncoder)

--- a/classify/main.py
+++ b/classify/main.py
@@ -1,25 +1,13 @@
 import argparse
 import os
 import logging
-import sys
 from datetime import datetime
 
+from ml_tools.logs import init_logging
 from ml_tools import tools
 from ml_tools.config import Config
 from ml_tools.previewer import Previewer
 from .clipclassifier import ClipClassifier
-
-def log_to_stdout():
-    """ Outputs all log entries to standard out. """
-    # taken from https://stackoverflow.com/questions/14058453/making-python-loggers-output-all-messages-to-stdout-in-addition-to-log
-    root = logging.getLogger()
-    root.setLevel(logging.INFO)
-
-    ch = logging.StreamHandler(sys.stdout)
-    ch.setLevel(logging.INFO)
-    formatter = logging.Formatter('%(message)s')
-    ch.setFormatter(formatter)
-    root.addHandler(ch)
 
 def main():
     parser = argparse.ArgumentParser()
@@ -34,9 +22,12 @@ def main():
         '--end-date', help='Only clips on or before this day will be processed (format YYYY-MM-DD)')
     parser.add_argument('-c', '--config-file', help="Path to config file to use")
     parser.add_argument('--processor-folder', help="When running from thermal-processing use this to specify the folder for both the source cptv and output mp4. With this option the metadata will be sent to stdout.")
-
+    parser.add_argument('-T', '--timestamps', action="store_true", help="Emit log timestamps")
     args = parser.parse_args()
+
     config = Config.load_from_file(args.config_file)
+
+    init_logging(args.timestamps)
 
     # parse command line arguments
     if args.create_previews:
@@ -58,9 +49,6 @@ def main():
         clip_classifier.start_date = datetime.strptime(args.start_date, "%Y-%m-%d")
     if args.end_date:
         clip_classifier.end_date = datetime.strptime(args.end_date, "%Y-%m-%d")
-
-    if not config.classify.meta_to_stdout:
-        log_to_stdout()
 
     if config.classify.preview != Previewer.PREVIEW_NONE:
         logging.info("Creating previews")

--- a/evaluate.py
+++ b/evaluate.py
@@ -21,13 +21,16 @@ import os
 import json
 from datetime import datetime, timedelta
 import dateutil.parser
-from ml_tools import tools
 import matplotlib.pyplot as plt
 from sklearn import metrics
 import numpy as np
 import itertools
 import argparse
 import seaborn as sns
+
+from ml_tools.logs import init_logging
+from ml_tools import tools
+
 
 # number of seconds between clips required to trigger a a new visit
 NEW_VISIT_THRESHOLD = 3*60
@@ -576,6 +579,8 @@ def print_evaluation(visits):
     show_errors_by_score(visits)
 
 def main():
+    init_logging()
+
     parser = argparse.ArgumentParser()
 
     parser.add_argument('-s', '--source-folder', default=os.path.join(DEFAULT_SOURCE_FOLDER), help='Source folder containing .txt files exported by classify.py')

--- a/extract.py
+++ b/extract.py
@@ -3,9 +3,12 @@ Processes a CPTV file identifying and tracking regions of interest, and saving t
 """
 
 import argparse
-import cv2
+import logging
 import os
 
+import cv2
+
+from ml_tools.logs import init_logging
 from ml_tools.trackdatabase import TrackDatabase
 from ml_tools import trackdatabase
 from ml_tools import tools
@@ -29,6 +32,8 @@ def parse_params():
         print(cv2.getBuildInformation())
         return
 
+    init_logging()
+
     config = Config.load_from_file(args.config_file)
     if args.create_previews:
         config.extract.preview = "tracking"
@@ -43,17 +48,17 @@ def parse_params():
         source_file = tools.find_file_from_cmd_line(config.source_folder, args.target)
         if source_file is None:
             return
-        print("Processing file '" + source_file + "'")
+        logging.info("Processing file '" + source_file + "'")
         tag = os.path.basename(os.path.dirname(source_file))
         extractor.process_file(source_file, tag=tag)
         return
 
     if args.target.lower() == 'test':
-        print("Running test suite")
+        logging.info("Running test suite")
         extractor.run_tests(args.source_folder, args.test_file)
         return
 
-    print('Processing tag "{0}"'.format(args.target))
+    logging.info('Processing tag "{0}"'.format(args.target))
 
     if args.target.lower() == 'all':
         extractor.clean_all()

--- a/ml_tools/logs.py
+++ b/ml_tools/logs.py
@@ -1,0 +1,16 @@
+import sys
+import logging
+
+
+def init_logging(timestamps=False):
+    """Set up logging for use by various classifier pipeline scripts.
+
+    Logs will go to stderr.
+    """
+
+    fmt = "%(levelname)7s %(message)s"
+    if timestamps:
+        fmt = "%(asctime)s " + fmt
+    logging.basicConfig(
+        stream=sys.stderr, level=logging.INFO, format=fmt, datefmt="%Y-%m-%d %H:%M:%S"
+    )

--- a/ml_tools/model.py
+++ b/ml_tools/model.py
@@ -286,7 +286,7 @@ class Model:
         print("-"*60)
         self.datasets.test.load_all()
         test_accuracy, _ = self.eval_batch(self.datasets.test.X, self.datasets.test.y, writer=writer)
-        print("Test Accuracy {0:.2f}% (error {1:.2f}%)".format(test_accuracy*100,(1.0-test_accuracy)*100))
+        logging.info("Test Accuracy %.2f (error %.2f%%)", test_accuracy * 100, (1.0 - test_accuracy) * 100)
         return test_accuracy
 
     def benchmark_model(self):

--- a/ml_tools/previewer.py
+++ b/ml_tools/previewer.py
@@ -1,3 +1,4 @@
+import logging
 from os import path
 
 import numpy as np
@@ -61,7 +62,7 @@ class Previewer:
             if path.exists(colourmap):
                 self.colormap = tools.load_colormap(colourmap)
             else:
-                print("using default colour map")
+                logging.info("using default colour map")
                 self.colormap = plt.get_cmap('jet')
 
         return globs._previewer_colour_map
@@ -93,7 +94,7 @@ class Previewer:
             self.auto_max = tracker.stats['max_temp']
             self.auto_min = tracker.stats['min_temp']
         else:
-            print("Do not have temperatures to use.")
+            logging.error("Do not have temperatures to use.")
             return
 
         if bool(track_predictions) and self.preview_type == self.PREVIEW_CLASSIFIED:
@@ -151,7 +152,7 @@ class Previewer:
                 img = img.resize((frame_width, frame_height), Image.NEAREST)
                 video_frames.append(np.asarray(img))
 
-            print("creating preview {}".format(filename_format.format(id + 1)))
+            logging.info("creating preview %s", filename_format.format(id + 1))
             tools.write_mpeg(filename_format.format(id + 1), video_frames)
 
 

--- a/ml_tools/tools.py
+++ b/ml_tools/tools.py
@@ -155,7 +155,7 @@ def find_file_from_cmd_line(root, cmd_line_input):
     if os.path.isfile(cmd_line_input):
         return cmd_line_input
 
-    print("Could not locate file '" + cmd_line_input + "'")
+    logging.warning("Could not locate %r", cmd_line_input)
     return None
 
 def get_ffmpeg_command(filename, width, height, quality=21):

--- a/ml_tools/trackdatabase.py
+++ b/ml_tools/trackdatabase.py
@@ -9,7 +9,9 @@ Handles reading and writing tracks (or segments) to a large database.  Uses HDF5
 """
 
 import os
+import logging
 from multiprocessing import Lock
+
 import h5py
 import tables           # required for blosc compression to work
 import numpy as np
@@ -56,7 +58,7 @@ class TrackDatabase:
         self.database = database_filename
 
         if not os.path.exists(database_filename):
-            print("Creating new database {}".format(database_filename))
+            logging.info("Creating new database %s", database_filename)
             f = h5py.File(database_filename, 'w')
             f.create_group("clips")
             f.close()

--- a/track/trackextractor.py
+++ b/track/trackextractor.py
@@ -374,9 +374,9 @@ class TrackExtractor:
         if self.config.verbose:
             for stats, track in track_stats:
                 start_s, end_s = self.start_and_end_in_secs(track)
-                print(" - track duration:{:.1f}sec, number of frames:{}, offset:{:.1f}px, delta:{:.1f}, mass:{:.1f}px".format(
+                logging.info(" - track duration: %.1fsec, number of frames:%s, offset:%.1fpx, delta:%.1f, mass:%.1fpx",
                     end_s - start_s, len(track), stats.max_offset, stats.delta_std, stats.average_mass
-                ))
+                )
 
         # find how much each track overlaps with other tracks
 
@@ -530,7 +530,7 @@ class TrackExtractor:
 
     def print_if_verbose(self, info_string):
         if self.config.verbose:
-            print(info_string)
+            logging.info(info_string)
 
     def get_video_stats(self):
         """

--- a/train.py
+++ b/train.py
@@ -39,8 +39,10 @@ import argparse
 import ast
 
 import tensorflow as tf
-
 from model_crnn import ModelCRNN_HQ, ModelCRNN_LQ
+
+from ml_tools.logs import init_logging
+
 
 # folder to put tensor board logs into
 LOG_FOLDER = "c:/cac/logs/"
@@ -200,6 +202,7 @@ def axis_search():
 
 
 def main():
+    init_logging()
 
     parser = argparse.ArgumentParser()
 


### PR DESCRIPTION
The goal was to fix a stray print to stdout which was breaking the
JSON output from classify.py (consumed by cacophony-processing).

Set things up so that logs go to stderr with a reasonable
format. stdout is then reserved for "data" output from the various
scripts. Most code sites that were using print are now using the
logging module.

Removed unused write_meta_to_stdout attribute.

Write out compressed JSON output.