### PR TITLE
build: use configuration file, fix track duration handling

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,28 +1,23 @@
 """
-Author: Matthew Aitchison
-Date: December 2017
-
 Build a segment dataset for training.
 Segment headers will be extracted from a track database and balanced according to class.
 Some filtering occurs at this stage as well, for example tracks with low confidence are excluded.
-
 """
 
-import os
-import random
-import math
-import pickle
-import time
-import dateutil
+import argparse
 import datetime
+import os
+import pickle
+import random
 
+import dateutil
 import numpy as np
 
 from ml_tools.logs import init_logging
 from ml_tools.trackdatabase import TrackDatabase
+from ml_tools.config import Config
 from ml_tools.dataset import Dataset
-
-DATASET_FOLDER = 'c:/cac/datasets/fantail/'
+from ml_tools.trackdatabase import TrackDatabase
 
 # uses split from previous run
 USE_PREVIOUS_SPLIT = True
@@ -356,13 +351,21 @@ def get_bin_split(filename):
         test_bins[label] = list(test_bins[label])
     return test_bins
 
+def load_config():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--config-file', help="Path to config file to use")
+    args = parser.parse_args()
+    return Config.load_from_file(args.config_file)
+
 def main():
     init_logging()
 
     global dataset
     global db
 
-    db = TrackDatabase(os.path.join(DATASET_FOLDER,'dataset.hdf5'))
+    config = load_config()
+
+    db = TrackDatabase(os.path.join(config.tracks_folder, 'dataset.hdf5'))
     dataset = Dataset(db, 'dataset')
 
     total_tracks = len(db.get_all_track_ids())
@@ -392,7 +395,7 @@ def main():
     else:
         datasets = split_dataset_days()
 
-    pickle.dump(datasets, open(os.path.join(DATASET_FOLDER,'datasets.dat'),'wb'))
+    pickle.dump(datasets, open(os.path.join(config.tracks_folder, 'datasets.dat'), 'wb'))
 
 
 if __name__ == "__main__":

--- a/build.py
+++ b/build.py
@@ -65,7 +65,7 @@ LABEL_WEIGHTS = {
 
 # clips after this date will be ignored.
 # note: this is based on the UTC date.
-END_DATE = datetime(2018, 1, 31)
+END_DATE = datetime.datetime(2018, 1, 31)
 
 # minimum average mass for test segment
 TEST_MIN_MASS = 30

--- a/build.py
+++ b/build.py
@@ -60,7 +60,7 @@ LABEL_WEIGHTS = {
 
 # clips after this date will be ignored.
 # note: this is based on the UTC date.
-END_DATE = datetime.datetime(2018, 1, 31)
+END_DATE = datetime.datetime(2019, 12, 31)
 
 # minimum average mass for test segment
 TEST_MIN_MASS = 30

--- a/classifier_TEMPLATE.yaml
+++ b/classifier_TEMPLATE.yaml
@@ -4,9 +4,13 @@ base_data_folder: "<full path>"
 # Enables/Disables GPU accelerated classification
 use_gpu: false
 
-# source_folder is where the cptv files reside under (could be in a subdirectory). It is specified relative
-# to the base_data_folder
+# source_folder is where the cptv files reside under. It is relative
+# to base_data_folder.
 source_folder: "cptv"
+
+# tracks_folder is where the track data files will be created. It is
+# specified relative to base_data_folder.
+tracks_folder: "tracks"
 
 # which folders (tags) to ignore when selecting cptv files from source_folder
 excluded_folders: ['untagged', 'cat', 'dog', 'insect', 'unidentified', 'rabbit', 'hard', 'multi', 'moving',
@@ -146,9 +150,6 @@ extract:
     # Note:  Set to 'False' is there is no hints file.
     # Note:  This is relative to the current directory of the application, not the base data folder
     hints_file: "hints.txt"
-
-    # tracks_folder is where the track files will be created.  It is specified relative to the base_data_folder
-    tracks_folder: "tracks"
 
 
 classify_tracking:

--- a/extract.py
+++ b/extract.py
@@ -9,7 +9,6 @@ import os
 import cv2
 
 from ml_tools.logs import init_logging
-from ml_tools.trackdatabase import TrackDatabase
 from ml_tools import trackdatabase
 from ml_tools import tools
 from ml_tools.config import Config

--- a/ml_tools/config.py
+++ b/ml_tools/config.py
@@ -14,11 +14,12 @@ CONFIG_DIRS = [Path(__file__).parent.parent, Path("/etc/cacophony")]
 
 @attr.s
 class Config:
+    source_folder = attr.ib()
+    tracks_folder = attr.ib()
     tracking = attr.ib()
     extract = attr.ib()
     classify_tracking = attr.ib()
     classify = attr.ib()
-    source_folder = attr.ib()
     excluded_folders = attr.ib()
     reprocess = attr.ib()
     previews_colour_map = attr.ib()
@@ -41,11 +42,12 @@ class Config:
 
         base_folder = path.expanduser(raw["base_data_folder"])
         return cls(
+            source_folder=path.join(base_folder, raw["source_folder"]),
+            tracks_folder=path.join(base_folder, raw.get("tracks_folder", "tracks")),
             tracking=TrackingConfig.load(raw["tracking"]),
-            extract=ExtractConfig.load(raw["extract"], base_folder),
+            extract=ExtractConfig.load(raw["extract"]),
             classify_tracking=TrackingConfig.load(raw["classify_tracking"]),
             classify=ClassifyConfig.load(raw["classify"], base_folder),
-            source_folder=path.join(base_folder, raw["source_folder"]),
             excluded_folders=raw["excluded_folders"],
             reprocess=raw["reprocess"],
             previews_colour_map=raw["previews_colour_map"],

--- a/ml_tools/cptvfileprocessor.py
+++ b/ml_tools/cptvfileprocessor.py
@@ -79,7 +79,8 @@ class CPTVFileProcessor:
 
         if self.workers_threads == 0:
             # just process the jobs in the main thread
-            for job in jobs: process_job(job)
+            for job in jobs:
+                process_job(job)
         else:
             # send the jobs to a worker pool
             pool = multiprocessing.Pool(self.workers_threads, initializer=self.worker_pool_init, initargs=worker_pool_args)

--- a/track/cptvtrackextractor.py
+++ b/track/cptvtrackextractor.py
@@ -44,8 +44,8 @@ class CPTVTrackExtractor(CPTVFileProcessor):
         # disables background subtraction
         self.disable_background_subtraction = False
 
-        os.makedirs(self.config.extract.tracks_folder, mode=0o775, exist_ok=True)
-        self.database = TrackDatabase(os.path.join(self.config.extract.tracks_folder, 'dataset.hdf5'))
+        os.makedirs(self.config.tracks_folder, mode=0o775, exist_ok=True)
+        self.database = TrackDatabase(os.path.join(self.config.tracks_folder, 'dataset.hdf5'))
 
         self.worker_pool_init = init_workers
 
@@ -82,7 +82,7 @@ class CPTVTrackExtractor(CPTVFileProcessor):
         previous_filter_setting = self.disable_track_filters
         previous_background_setting = self.disable_background_subtraction
 
-        for root, folders, _ in os.walk(root):
+        for _, folders, _ in os.walk(root):
             for folder in folders:
                 if folder not in self.config.excluded_folders:
                     if folder.lower() == "false-positive":
@@ -146,7 +146,7 @@ class CPTVTrackExtractor(CPTVFileProcessor):
 
         logging.info(f"processing %s", cptv_filename)
 
-        destination_folder = os.path.join(self.config.extract.tracks_folder, tag.lower())
+        destination_folder = os.path.join(self.config.tracks_folder, tag.lower())
         os.makedirs(destination_folder, mode=0o775, exist_ok=True)
         # delete any previous files
         tools.purge(destination_folder, base_filename + "*.mp4")

--- a/track/extractconfig.py
+++ b/track/extractconfig.py
@@ -17,8 +17,6 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 """
 
-import os.path as path
-
 import attr
 
 
@@ -29,14 +27,12 @@ class ExtractConfig:
     include_filtered_channel = attr.ib()
     preview = attr.ib()
     hints_file = attr.ib()
-    tracks_folder = attr.ib()
 
     @classmethod
-    def load(cls, extract, base_folder):
+    def load(cls, extract):
         return cls(
             enable_compression=extract["enable_compression"],
             include_filtered_channel=extract["include_filtered_channel"],
             preview=extract["preview"],
             hints_file=extract["hints_file"],
-            tracks_folder=path.join(base_folder, extract["tracks_folder"]),
         )


### PR DESCRIPTION
- build.py now uses classifier.yaml
- tracks_folder moved out of extract section of config. It's used in more than once place.
- build.py now uses track_folder config instead of hardcoded path
- various import fixes
- use a later end date in the build step
- calculate track duration on the fly - it no longer seems to be in the track metadata