### PR TITLE
Remove constants in train.py

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -107,7 +107,7 @@ python build.py
 
 This will take a minute or so.
 
-By default only clips up to a certian date will be processed, so it may be necessary to edit the `build.py` and edit the line
+By default only clips up to a certain date will be processed, so it may be necessary to edit the `build.py` and edit the line
 
 ```python
 END_DATE = datetime(2018, 1, 31)
@@ -214,7 +214,8 @@ python train.py
 
 # 5.1 Using Tensorboard to monitor training
 
-To view a model while training you can run Tensorboard from the command prompt.  By default logs are placed in the folder 'c:/cac/logs'.
+To view a model while training you can run Tensorboard from the command prompt.  Logs are placed in the
+logs subdirectory of the base data directory.
 It is often a good idea to group logs from related runs together in a folder.  For example 'c:/cac/logs/v030/optical flow test/'
 
 ```commandline

--- a/build.py
+++ b/build.py
@@ -1,8 +1,7 @@
-"""
-Build a segment dataset for training.
-Segment headers will be extracted from a track database and balanced according to class.
-Some filtering occurs at this stage as well, for example tracks with low confidence are excluded.
-"""
+# Build a segment dataset for training.
+# Segment headers will be extracted from a track database and balanced
+# according to class. Some filtering occurs at this stage as well, for example
+# tracks with low confidence are excluded.
 
 import argparse
 import datetime
@@ -16,8 +15,7 @@ import numpy as np
 from ml_tools.logs import init_logging
 from ml_tools.trackdatabase import TrackDatabase
 from ml_tools.config import Config
-from ml_tools.dataset import Dataset
-from ml_tools.trackdatabase import TrackDatabase
+from ml_tools.dataset import Dataset, dataset_db_path
 
 # uses split from previous run
 USE_PREVIOUS_SPLIT = True
@@ -80,7 +78,6 @@ filtered_stats = {"confidence": 0, "trap": 0, "banned": 0, "date": 0}
 
 
 def track_filter(clip_meta, track_meta):
-
     # some clips are banned for various reasons
     source = os.path.basename(clip_meta["filename"])
     if source in BANNED_CLIPS:
@@ -143,28 +140,26 @@ def show_segments_breakdown():
 
 
 def split_dataset_predefined():
-    """
-    Splits dataset into train / test / validation using a predefined set of camerea-label allocations.
+    """Splits dataset into train / test / validation using a predefined set of camera-label allocations.
 
-    This method puts all tracks into 'camera-label' bins and then assigns certian bins to the validation set.
+    This method puts all tracks into 'camera-label' bins and then assigns certain bins to the validation set.
     In this case the 'test' set is simply a subsample of the validation set. (as there are not enough unique cameras
     at this point for 3 sets).
 
     The advantages of this method are
 
     1/ The datasets are fixed, even as more footage comes through
-    2/ Learning an animal on one camera / enviroment and predicting it on another is a very good indicator that that
+    2/ Learning an animal on one camera / environment and predicting it on another is a very good indicator that that
         algorthim has generalised
-    3/ Some adjustment can be made to make sure that the cameras used in the test / validation sets contain 'resonable'
+    3/ Some adjustment can be made to make sure that the cameras used in the test / validation sets contain 'reasonable'
         footage. (i.e. footage that is close to what we want to classify.
 
     The disadvantages are that it requires seeing animals on multiple cameras, which we don't always have data for.
     It can also be a bit wasteful as we sometimes dedicate a substantial portion of the data to some animal types.
 
-    A posiable solution would be to note when (or if) the model over-fits then run on the entire dataset.
+    A possible solution would be to note when (or if) the model over-fits then run on the entire dataset.
 
     Another option would be k-fold validation.
-
     """
 
     validation_bins = [
@@ -367,7 +362,7 @@ def split_dataset_days(prefill_bins=None):
 
 
 def get_bin_split(filename):
-    """ Loads bin splits from previous database. """
+    """Loads bin splits from previous database. """
     train, validation, text = pickle.load(open(filename, "rb"))
     test_bins = {}
     for label in validation.labels:
@@ -427,9 +422,7 @@ def main():
     else:
         datasets = split_dataset_days()
 
-    pickle.dump(
-        datasets, open(os.path.join(config.tracks_folder, "datasets.dat"), "wb")
-    )
+    pickle.dump(datasets, open(dataset_db_path(config), "wb"))
 
 
 if __name__ == "__main__":

--- a/ml_tools/config.py
+++ b/ml_tools/config.py
@@ -16,6 +16,7 @@ CONFIG_DIRS = [Path(__file__).parent.parent, Path("/etc/cacophony")]
 class Config:
     source_folder = attr.ib()
     tracks_folder = attr.ib()
+    logs_folder = attr.ib()
     tracking = attr.ib()
     extract = attr.ib()
     classify_tracking = attr.ib()
@@ -44,6 +45,7 @@ class Config:
         return cls(
             source_folder=path.join(base_folder, raw["source_folder"]),
             tracks_folder=path.join(base_folder, raw.get("tracks_folder", "tracks")),
+            logs_folder=path.join(base_folder, "logs"),
             tracking=TrackingConfig.load(raw["tracking"]),
             extract=ExtractConfig.load(raw["extract"]),
             classify_tracking=TrackingConfig.load(raw["classify_tracking"]),

--- a/ml_tools/dataset.py
+++ b/ml_tools/dataset.py
@@ -982,3 +982,7 @@ def get_cropped_fraction(region: tools.Rectangle, width, height):
     """ Returns the fraction regions mass outside the rect ((0,0), (width, height)"""
     bounds = tools.Rectangle(0, 0, width - 1, height - 1)
     return 1 - (bounds.overlap_area(region) / region.area)
+
+
+def dataset_db_path(config):
+    return os.path.join(config.tracks_folder, "datasets.dat")


### PR DESCRIPTION
Similar cleanup to elsewhere.

Bonus features, typos, grammar, docstrings and a lifted out function
to permit DRY around the datasets.dat file location logic.