### PR TITLE
Also apply track filtering when background is preview

### DIFF
--- a/ml_tools/config.py
+++ b/ml_tools/config.py
@@ -55,7 +55,8 @@ class Config(DefaultConfig):
         default = Config.get_defaults()
         if raw is None:
             raw = {}
-        # "tracking" params are overrides, add other parameters from "classify_tracking"
+        # Configuration from "tracking" section is used in
+        # "classify_tracking" when not specified.
         deep_copy_map_if_key_not_exist(raw["tracking"], raw["classify_tracking"])
         deep_copy_map_if_key_not_exist(default.as_dict(), raw)
 


### PR DESCRIPTION
Track filtering was only being applied when clip.background_is_preview was False.

Also fixed a number of incorrect name references. This code has clearly not been run since being refactored.