### PR TITLE
Use load weights instead of load model

### DIFF
--- a/classify/clipclassifier.py
+++ b/classify/clipclassifier.py
@@ -27,13 +27,13 @@ class ClipClassifier(CPTVFileProcessor):
     # skips every nth frame.  Speeds things up a little, but reduces prediction quality.
     FRAME_SKIP = 1
 
-    def __init__(self, config, tracking_config, model_file):
+    def __init__(self, config, tracking_config, model_file, kerasmodel=False):
         """ Create an instance of a clip classifier"""
 
         super(ClipClassifier, self).__init__(config, tracking_config)
         self.model_file = model_file
         path, ext = os.path.splitext(self.model_file)
-        self.kerasmodel = ext != ".sav"
+        self.kerasmodel = kerasmodel
         # prediction record for each track
         self.predictions = Predictions(self.classifier.labels)
 
@@ -178,7 +178,7 @@ class ClipClassifier(CPTVFileProcessor):
             logging.info("classifier loading")
             if self.kerasmodel:
                 model = KerasModel(self.config.train)
-                model.load_model(self.model_file)
+                model.load_weights(self.model_file)
                 globs._classifier = model
             else:
                 globs._classifier = Model(

--- a/classify/main.py
+++ b/classify/main.py
@@ -74,17 +74,21 @@ def main():
         model_file = args.model_file
 
     path, ext = os.path.splitext(model_file)
-    if ext != ".sav":
-        if not os.path.exists(os.path.join(model_file, "saved_model.pb")):
-            logging.error(
-                "No model found named '{}'.".format(model_file + ".save_model.pb")
-            )
+    keras_model = False
+    if ext == ".pb":
+        keras_model = True
+        print(os.path.dirname(model_file))
+        weights_path = os.path.dirname(model_file) + "/variables/variables.index"
+        if not os.path.exists(os.path.join(weights_path)):
+            logging.error("No weights found named '{}'.".format(weights_path))
             exit(13)
     elif not os.path.exists(model_file + ".meta"):
         logging.error("No model found named '{}'.".format(model_file + ".meta"))
         exit(13)
 
-    clip_classifier = ClipClassifier(config, config.classify_tracking, model_file)
+    clip_classifier = ClipClassifier(
+        config, config.classify_tracking, model_file, keras_model
+    )
 
     # parse start and end dates
     if args.start_date:


### PR DESCRIPTION
To make old a new keras models work with the same tensorflow verison it has to be 2.1.0
The new model was build with 2.2.0 which wont load properly using load_model so have to load via the weights.

This requires building the model structure and then applying the weights.

Also made it use keras models if the supplied model is of .pb format