### PR TITLE
Tracking fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ may require manual editing to setup the tests if the original browse video did n
 well
 - Test CPTV files will be saved under out_dir and labelled as recordingid.cptv
 
-`python tests\generatetests.py out_dir Username Password <list of recording ids separated by a space>`
+`python generatetests.py out_dir Username Password <list of recording ids separated by a space>`
 
 e.g.
 
-`python tests\generatetests.py test_clips Derek password123 12554 122232`
+`python generatetests.py test_clips Derek password123 12554 122232`
 
 ## Running Tests
 

--- a/classifier_TEMPLATE.yaml
+++ b/classifier_TEMPLATE.yaml
@@ -72,6 +72,8 @@ tracking:
           - camera_model: "lepton3"
             # Default temperature threshold require for tracking
             temp_thresh: 2900
+            background_thresh: 20 # 1 degrees
+
             # Minimum raw temperature difference between background and track
             delta_thresh: 20
             # Min/Max temperature threshold value to use if dynamic threshold is true
@@ -83,12 +85,13 @@ tracking:
             track_max_delta: 150
           - camera_model: "lepton3.5"
             temp_thresh: 28000
+            background_thresh: 100 # 1 degrees
             delta_thresh: 100 # 1 degrees
             max_temp_thresh: null
             min_temp_thresh: null
             # discard tracks that do not have enough delta within the window (i.e. pixels that change a lot)
-            track_min_delta: 90
-            track_max_delta: 1500
+            track_min_delta: 1.0
+            track_max_delta: 150
     # these parameters are associated with the stats background method
     stats:
         # auto threshold needs to find a near maximum value to calculate the threshold level

--- a/classifier_TEMPLATE.yaml
+++ b/classifier_TEMPLATE.yaml
@@ -85,8 +85,8 @@ tracking:
             track_max_delta: 150
           - camera_model: "lepton3.5"
             temp_thresh: 28000
-            background_thresh: 100 # 1 degrees
-            delta_thresh: 100 # 1 degrees
+            background_thresh: 90 # .9 degrees
+            delta_thresh: 90 # .9 degrees
             max_temp_thresh: null
             min_temp_thresh: null
             # discard tracks that do not have enough delta within the window (i.e. pixels that change a lot)

--- a/classifier_TEMPLATE.yaml
+++ b/classifier_TEMPLATE.yaml
@@ -87,7 +87,7 @@ tracking:
             max_temp_thresh: null
             min_temp_thresh: null
             # discard tracks that do not have enough delta within the window (i.e. pixels that change a lot)
-            track_min_delta: 100
+            track_min_delta: 90
             track_max_delta: 1500
     # these parameters are associated with the stats background method
     stats:

--- a/classify/clipclassifier.py
+++ b/classify/clipclassifier.py
@@ -261,7 +261,7 @@ class ClipClassifier(CPTVFileProcessor):
         save_file["end_time"] = end.isoformat()
         save_file["algorithm"] = {}
         save_file["algorithm"]["model"] = self.model_file
-        save_file["algorithm"]["tracker_version"] = clip.VERSION
+        save_file["algorithm"]["tracker_version"] = ClipTrackExtractor.VERSION
         save_file["algorithm"]["tracker_config"] = self.tracker_config.as_dict()
         if meta_data:
             save_file["camera"] = meta_data["Device"]["devicename"]

--- a/classify/clipclassifier.py
+++ b/classify/clipclassifier.py
@@ -255,7 +255,6 @@ class ClipClassifier(CPTVFileProcessor):
         save_file["source"] = filename
         if clip.camera_model:
             save_file["camera_model"] = clip.camera_model
-        save_file["temp_thresh"] = clip.temp_thresh
         save_file["background_thresh"] = clip.background_thresh
         start, end = clip.start_and_end_time_absolute()
         save_file["start_time"] = start.isoformat()

--- a/classify/trackprediction.py
+++ b/classify/trackprediction.py
@@ -298,7 +298,7 @@ class TrackPrediction:
         guesses = [
             "{} ({:.1f})".format(labels[self.label_index(i)], self.score(i) * 10)
             for i in range(1, min(len(labels), 4))
-            if self.score(i) > 0.5
+            if self.score(i) and self.score(i) > 0.5
         ]
         return guesses
 

--- a/config/trackingconfig.py
+++ b/config/trackingconfig.py
@@ -105,8 +105,8 @@ class TrackingConfig(DefaultConfig):
             enable_track_output=tracking["enable_track_output"],
             min_tag_confidence=tracking["min_tag_confidence"],
             min_moving_frames=tracking["min_moving_frames"],
+            max_blank_percent=tracking["max_blank_percent"],
             max_mass_std_percent=tracking["max_mass_std_percent"],
-            max_mass_std=tracking["max_mass_std"],
             max_jitter=tracking["max_jitter"],
             stats=None,
             filters=None,
@@ -164,7 +164,7 @@ class TrackingConfig(DefaultConfig):
             min_moving_frames=2,
             max_blank_percent=30,
             max_mass_std_percent=ClipTrackExtractor.MASS_CHANGE_PERCENT,
-            max_jitter=15,
+            max_jitter=20,
         )
 
     def validate(self):

--- a/config/trackingconfig.py
+++ b/config/trackingconfig.py
@@ -58,6 +58,8 @@ class TrackingConfig(DefaultConfig):
     moving_vel_thresh = attr.ib()
     min_moving_frames = attr.ib()
     max_blank_percent = attr.ib()
+    max_mass_std_percent = attr.ib()
+
     max_jitter = attr.ib()
     # used to provide defaults
     stats = attr.ib()
@@ -103,7 +105,8 @@ class TrackingConfig(DefaultConfig):
             enable_track_output=tracking["enable_track_output"],
             min_tag_confidence=tracking["min_tag_confidence"],
             min_moving_frames=tracking["min_moving_frames"],
-            max_blank_percent=tracking["max_blank_percent"],
+            max_mass_std_percent=tracking["max_mass_std_percent"],
+            max_mass_std=tracking["max_mass_std"],
             max_jitter=tracking["max_jitter"],
             stats=None,
             filters=None,
@@ -160,6 +163,7 @@ class TrackingConfig(DefaultConfig):
             moving_vel_thresh=4,
             min_moving_frames=2,
             max_blank_percent=30,
+            max_mass_std_percent=ClipTrackExtractor.MASS_CHANGE_PERCENT,
             max_jitter=15,
         )
 

--- a/generatetests.py
+++ b/generatetests.py
@@ -1,0 +1,3 @@
+from tests.generatetests import main
+
+main()

--- a/load/clip.py
+++ b/load/clip.py
@@ -37,7 +37,7 @@ class Clip:
     PREVIEW = "preview"
     FRAMES_PER_SECOND = 9
     local_tz = pytz.timezone("Pacific/Auckland")
-    VERSION = 8
+    VERSION = 9
     CLIP_ID = 1
     # used when calculating background, mininimum percentage the difference object
     # and background object must overlap i.e. they are a valid object

--- a/load/cliptrackextractor.py
+++ b/load/cliptrackextractor.py
@@ -44,6 +44,7 @@ class ClipTrackExtractor:
 
     MAX_DISTANCE = 2000
     PREVIEW = "preview"
+    VERSION = 9
 
     def __init__(
         self, config, use_opt_flow, cache_to_disk, keep_frames=True, calc_stats=True

--- a/load/cliptrackextractor.py
+++ b/load/cliptrackextractor.py
@@ -170,24 +170,23 @@ class ClipTrackExtractor:
                         prev_filtered,
                     )
         else:
-            regions = self._get_regions_of_interest(
-                clip, component_details, filtered, prev_filtered
-            )
+            regions = []
+            if ffc_affected:
+                clip.active_tracks = set()
+            else:
+                regions = self._get_regions_of_interest(
+                    clip, component_details, filtered, prev_filtered
+                )
+                self._apply_region_matchings(clip, regions)
             clip.region_history.append(regions)
-            self._apply_region_matchings(
-                clip, regions, create_new_tracks=not ffc_affected
-            )
 
-    def _apply_region_matchings(self, clip, regions, create_new_tracks=True):
+    def _apply_region_matchings(self, clip, regions):
         """
         Work out the best matchings between tracks and regions of interest for the current frame.
         Create any new tracks required.
         """
         unmatched_regions, matched_tracks = self._match_existing_tracks(clip, regions)
-        if create_new_tracks:
-            new_tracks = self._create_new_tracks(clip, unmatched_regions)
-        else:
-            new_tracks = set()
+        new_tracks = self._create_new_tracks(clip, unmatched_regions)
         self._filter_inactive_tracks(clip, new_tracks, matched_tracks)
 
     def _match_existing_tracks(self, clip, regions):

--- a/load/cliptrackextractor.py
+++ b/load/cliptrackextractor.py
@@ -432,10 +432,13 @@ class ClipTrackExtractor:
             )
             clip.filtered_tracks.append(("Track filtered.  Didn't move", track))
             return True
-        # if stats.mass_std > stats.average_mass * self.config.max_mass_std_percent:
-        #     self.print_if_verbose("Track filtered.  Mass too deviant")
-        #     clip.filtered_tracks.append(("Track filtered. Mass too deviant", track))
-        #     return True
+        if (
+            stats.average_velocity <= 2
+            and stats.mass_std > stats.average_mass * self.config.max_mass_std_percent
+        ):
+            self.print_if_verbose("Track filtered.  Mass too deviant")
+            clip.filtered_tracks.append(("Track filtered. Mass too deviant", track))
+            return True
         if stats.blank_percent > self.config.max_blank_percent:
             self.print_if_verbose("Track filtered.  Too Many Blanks")
             clip.filtered_tracks.append(("Track filtered. Too Many Blanks", track))

--- a/ml_tools/previewer.py
+++ b/ml_tools/previewer.py
@@ -160,6 +160,8 @@ class Previewer:
                 self.add_tracks(
                     draw, clip.tracks, frame_number, predictions, screen_bounds
                 )
+            if frame.ffc_affected:
+                self.add_header(draw, image.width, image.height, "Calibrating ...")
             if self.debug and draw:
                 self.add_footer(
                     draw, image.width, image.height, footer, frame.ffc_affected
@@ -268,6 +270,17 @@ class Previewer:
                         v_offset=v_offset,
                         frame_offset=frame_offset,
                     )
+
+    def add_header(
+        self,
+        draw,
+        width,
+        height,
+        text,
+    ):
+        footer_size = self.font.getsize(text)
+        center = (width / 2 - footer_size[0] / 2.0, 5)
+        draw.text((center[0], center[1]), text, font=self.font)
 
     def add_footer(self, draw, width, height, text, ffc_affected):
         footer_text = "FFC {} {}".format(ffc_affected, text)

--- a/ml_tools/previewer.py
+++ b/ml_tools/previewer.py
@@ -130,7 +130,9 @@ class Previewer:
                 )
                 draw = ImageDraw.Draw(image)
             elif self.preview_type == self.PREVIEW_TRACKING:
-                image = self.create_four_tracking_image(frame, clip.stats.min_temp)
+                image = self.create_four_tracking_image(
+                    frame, clip.stats.min_temp, clip.stats.max_temp
+                )
                 image = self.convert_and_resize(
                     image,
                     clip.stats.min_temp,
@@ -430,11 +432,12 @@ class Previewer:
                 )
 
     @staticmethod
-    def create_four_tracking_image(frame, min_temp):
+    def create_four_tracking_image(frame, min_temp, max_temp):
 
         thermal = frame.thermal
         filtered = frame.filtered + min_temp
-        mask = frame.mask * 10000
+        mask = frame.mask.copy()
+        mask[mask > 0] = max_temp
         flow_h, flow_v = frame.get_flow_split(clip_flow=True)
         if flow_h is None and flow_v is None:
             flow_magnitude = filtered

--- a/piclassifier/piclassifier.py
+++ b/piclassifier/piclassifier.py
@@ -301,7 +301,7 @@ class PiClassifier(Processor):
         save_file["temp_thresh"] = self.clip.temp_thresh
         save_file["algorithm"] = {}
         save_file["algorithm"]["model"] = self.config.classify.model
-        save_file["algorithm"]["tracker_version"] = self.clip.VERSION
+        save_file["algorithm"]["tracker_version"] = ClipTrackExtractor.VERSION
         save_file["tracks"] = []
         for track in self.clip.tracks:
             track_info = {}

--- a/tests/lepton35-tracking-tests.yml
+++ b/tests/lepton35-tracking-tests.yml
@@ -1,0 +1,140 @@
+!TestConfig
+clip_dir: tests/lepton35
+recording_tests:
+- !TestRecording
+  device: Eliminator 6
+  device_id: 1419
+  filename: 780559.cptv
+  group: akaroa01
+  group_id: 18
+  rec_id: 780559
+  tracks:
+  - !TestTrack
+    confidence: null
+    end: 65.89
+    end_pos:
+    - 65.89
+    - [1, 61, 35, 96]
+    expected: true
+    id: 780559
+    opt_end: 65.89
+    opt_start: 0
+    start: 0
+    start_pos:
+    - 0
+    - [8, 70, 41, 108]
+    tag: cat
+    track_id: 334991
+- !TestRecording
+  device: KZ8_1
+  device_id: 1348
+  filename: 783516.cptv
+  group: kaitorete
+  group_id: 202
+  rec_id: 783516
+  tracks:
+  - !TestTrack
+    confidence: null
+    end: 13
+    end_pos:
+    - 14.3
+    - [1, 32, 20, 50]
+    expected: true
+    id: 783516
+    opt_end: 14.3
+    opt_start: 2.56
+    start: 2.56
+    start_pos:
+    - 2.56
+    - [154, 32, 159, 50]
+    tag: leporidae
+    track_id: 336238
+- !TestRecording
+  device: KZ8_2
+  device_id: 1349
+  filename: 783303.cptv
+  group: kaitorete
+  group_id: 202
+  rec_id: 783303
+  tracks:
+  - !TestTrack
+    confidence: 0.85
+    end: 8
+    end_pos:
+    - 8
+    - [1, 58, 12, 81]
+    expected: true
+    id: 783303
+    opt_end: 8
+    opt_start: 5
+    start: 5
+    start_pos:
+    - 5
+    - [1, 62, 6, 79]
+    tag: unknown
+    track_id: 336199
+  - !TestTrack
+    confidence: null
+    end: 7.44
+    end_pos:
+    - 7.44
+    - [36, 38, 61, 56]
+    expected: true
+    id: 783303
+    opt_end: 7.44
+    opt_start: 3
+    start: 3
+    start_pos:
+    - 3
+    - [1, 62, 12, 80]
+    tag: null
+    track_id: 336198
+- !TestRecording
+  device: Eliminator7
+  device_id: 1426
+  filename: 780825.cptv
+  group: akaroa01
+  group_id: 18
+  rec_id: 780825
+  tracks:
+  - !TestTrack
+    confidence: 0.64
+    end: 44.44
+    end_pos:
+    - 44.44
+    - [110, 1, 159, 69]
+    expected: true
+    id: 780825
+    opt_end: 44.11
+    opt_start: 0.56
+    start: 0.56
+    start_pos:
+    - 44.11
+    - [92, 7, 159, 119]
+    tag: possum
+    track_id: 0
+- !TestRecording
+  device: Stoat hunter
+  device_id: 1435
+  filename: 783988.cptv
+  group: Shakespear Park
+  group_id: 207
+  rec_id: 783988
+  tracks:
+  - !TestTrack
+    confidence: 0.8
+    end: 5.11
+    end_pos:
+    - 5.11
+    - [114, 85, 122, 93]
+    expected: true
+    id: 783988
+    opt_end: 5.11
+    opt_start: 1.33
+    start: 1.33
+    start_pos:
+    - 1.33
+    - [143, 91, 150, 98]
+    tag: mustelid
+    track_id: 336487
+server: https://api.cacophony.org.nz

--- a/tests/testconfig.py
+++ b/tests/testconfig.py
@@ -24,7 +24,6 @@ class TestConfig(yaml.YAMLObject):
 @attr.s
 class TestRecording(yaml.YAMLObject):
     yaml_tag = "!TestRecording"
-
     rec_id = attr.ib()
     filename = attr.ib()
     device_id = attr.ib()
@@ -36,7 +35,7 @@ class TestRecording(yaml.YAMLObject):
     @classmethod
     def load_from_meta(cls, rec_meta, track_meta, filepath):
         rec_id = rec_meta["id"]
-        filename = str(filepath.with_suffix(".cptv").absolute())
+        filename = filepath.name
         device_id = rec_meta["Device"]["id"]
         device = rec_meta["Device"]["devicename"]
         group_id = rec_meta["GroupId"]
@@ -47,7 +46,7 @@ class TestRecording(yaml.YAMLObject):
             tag = get_best_tag(track)
             if tag is None:
                 tag = {}
-            test_track = TestTrack.load_from_meta(track, tag)
+            test_track = TestTrack.load_from_meta(rec_id, track, tag)
             tracks.append(test_track)
         return cls(rec_id, filename, device_id, device, group_id, group, tracks)
 
@@ -68,10 +67,11 @@ class TestTrack(yaml.YAMLObject):
     expected = attr.ib()
 
     @classmethod
-    def load_from_meta(cls, track, tag):
+    def load_from_meta(cls, rec_id, track, tag):
         start = track["data"]["start_s"]
         end = track["data"]["end_s"]
         return cls(
+            id=rec_id,
             track_id=track["id"],
             tag=tag.get("what"),
             start=start,

--- a/tests/trackingtest.py
+++ b/tests/trackingtest.py
@@ -2,7 +2,6 @@ import attr
 import absl.logging
 import argparse
 import os
-import json
 import logging
 import math
 import sys
@@ -166,7 +165,7 @@ class RecordingMatch:
         self.matches.append(match)
 
     def print_summary(self):
-        print("*******{} Results ******".format(self.id))
+        print("*******{} Classification Results ******".format(self.id))
         print(
             "matches {}\tmismatches {}\tunmatched {}".format(
                 self.summary.classified_correct,
@@ -288,7 +287,6 @@ class Match:
 class TestClassify:
     def __init__(self, args):
         self.test_config = TestConfig.load_from_file(args.tests)
-
         self.classifier_config = Config.load_from_file(args.classify_config)
         model_file = self.classifier_config.classify.model
         if args.model_file:
@@ -314,7 +312,7 @@ class TestClassify:
                 filepath = out_dir / test.filename
                 if not filepath.exists():
                     if iter_to_file(
-                        out_dir / test.filename, api.download_recording(test.rec_id)
+                        out_dir / test.filename, api.download_raw(test.rec_id)
                     ):
                         logging.info("Saved %s", filepath)
         self.results = []

--- a/track/track.py
+++ b/track/track.py
@@ -190,7 +190,7 @@ class Track:
     def average_mass(self):
         """ Average mass of last 5 frames that weren't blank """
         return np.mean(
-            [bound.mass for bound in self.bounds_history if bound.blank == False][-5:]
+            [bound.mass for bound in self.bounds_history if bound.blank == False][-3:]
         )
 
     def add_blank_frame(self, buffer_frame=None):

--- a/track/track.py
+++ b/track/track.py
@@ -240,12 +240,10 @@ class Track:
 
         frames_moved = 0
         avg_vel = 0
-        count = 0
         first_point = self.bounds_history[0].mid
         for i, (vx, vy) in enumerate(zip(self.vel_x, self.vel_y)):
             region = self.bounds_history[i]
             if not region.blank:
-                count += 1
                 avg_vel += abs(vx) + abs(vy)
             if i == 0:
                 continue
@@ -258,7 +256,7 @@ class Track:
                 offset = eucl_distance(first_point, region.mid)
                 max_offset = max(max_offset, offset)
                 frames_moved += 1
-        avg_vel = avg_vel / count
+        avg_vel = avg_vel / len(mass_history)
         # the standard deviation is calculated by averaging the per frame variances.
         # this ends up being slightly different as I'm using /n rather than /(n-1) but that
         # shouldn't make a big difference as n = width*height*frames which is large.


### PR DESCRIPTION
Lepton3.5 min and max delta should be the same as lepton3.0 as filtered frames are normalized to be within 0-255.
Stop tracking when ffc events occur
Match tracks also based on calculated mass
Chanage velocity stats to be based of region matches (not blank frames)
Adjusted jitter thershold to be less strict
Added lepton3.5 tests