### PR TITLE
add cache to disk as cmd line, and cache as float32

### DIFF
--- a/classify/clipclassifier.py
+++ b/classify/clipclassifier.py
@@ -26,7 +26,7 @@ class ClipClassifier(CPTVFileProcessor):
     # skips every nth frame.  Speeds things up a little, but reduces prediction quality.
     FRAME_SKIP = 1
 
-    def __init__(self, config, tracking_config, model=None):
+    def __init__(self, config, tracking_config, model=None, cache_to_disk=None):
         """Create an instance of a clip classifier"""
 
         super(ClipClassifier, self).__init__(config, tracking_config)
@@ -37,14 +37,17 @@ class ClipClassifier(CPTVFileProcessor):
 
         self.start_date = None
         self.end_date = None
-        self.cache_to_disk = self.config.classify.cache_to_disk
+        if cache_to_disk is None:
+            self.cache_to_disk = self.config.classify.cache_to_disk
+        else:
+            self.cache_to_disk = cache_to_disk
         # enables exports detailed information for each track.  If preview mode is enabled also enables track previews.
         self.enable_per_track_information = False
         self.track_extractor = ClipTrackExtractor(
             self.config.tracking,
             self.config.use_opt_flow
             or config.classify.preview == Previewer.PREVIEW_TRACKING,
-            self.config.classify.cache_to_disk,
+            self.cache_to_disk,
         )
 
     def preprocess(self, frame, thermal_reference):
@@ -80,13 +83,12 @@ class ClipClassifier(CPTVFileProcessor):
             except ValueError:
                 fp_index = None
 
-            track_prediction = (
-                TrackPrediction(track.get_id(), track.start_frame, fp_index, keep_all),
+            track_prediction = TrackPrediction(
+                track.get_id(), track.start_frame, fp_index
             )
 
             for i, region in enumerate(track.bounds_history):
                 frame = clip.frame_buffer.get_frame(region.frame_number)
-
                 track_data = track.crop_by_region(frame, region)
 
                 # note: would be much better for the tracker to store the thermal references as it goes.

--- a/ml_tools/framecache.py
+++ b/ml_tools/framecache.py
@@ -33,15 +33,24 @@ class FrameCache:
 
         dims = (5, height, width)
         frame_node = frame_group.create_dataset(
-            "frame", dims, chunks=chunks, dtype=np.float16
+            "frame", dims, chunks=chunks, dtype=np.float32
         )
-        scaled_flow = get_clipped_flow(frame.flow)
+        scaled_flow_h = None
+        scaled_flow_v = None
+        if frame.flow is not None:
+            scaled_flow = get_clipped_flow(frame.flow)
+            scaled_flow_h = np.float32(scaled_flow[:, :, 0])
+            scaled_flow_v = np.float32(scaled_flow[:, :, 1])
+        else:
+            scaled_flow_h = np.zeros(frame.thermal.shape, dtype=np.float32)
+            scaled_flow_v = scaled_flow_h
+
         frame_val = (
-            np.float16(frame.thermal),
-            np.float16(frame.filtered),
-            np.float16(scaled_flow[:, :, 0]),
-            np.float16(scaled_flow[:, :, 1]),
-            np.float16(frame.mask),
+            np.float32(frame.thermal),
+            np.float32(frame.filtered),
+            scaled_flow_h,
+            scaled_flow_v,
+            np.float32(frame.mask),
         )
         frame_node[:, :, :] = frame_val
         if not self.keep_open:

--- a/track/framebuffer.py
+++ b/track/framebuffer.py
@@ -147,7 +147,7 @@ class FrameBuffer:
         self.calc_flow = calc_flow
         self.keep_frames = keep_frames
         self.current_frame = 0
-        if cache_to_disk or calc_flow:
+        if calc_flow:
             self.set_optical_flow()
         self.reset()
 


### PR DESCRIPTION
This can be used by processing to not cache smaller cptv files and improve performance.

Also noticed that was getting different classifications with cached and non cached due to it being cached as float16

When caching was always doing optical flow, changed so it doesn't bother when it isnt needed